### PR TITLE
[fix] Fixed the issue in the runtime result sorting order of OIV6

### DIFF
--- a/compressai_vision/pipelines/split_inference/image_split_inference.py
+++ b/compressai_vision/pipelines/split_inference/image_split_inference.py
@@ -222,6 +222,19 @@ class ImageSplitInference(BasePipeline):
             out_res["input_size"] = dec_features["input_size"][0]
             output_list.append(out_res)
 
+        if not self.configs["codec"]["decode_only"]:
+            accum_enc_by_module = {
+                key: accum_enc_by_module[key]
+                for key in ["feature_reduction", "conversion", "inner_codec"]
+                if key in accum_enc_by_module
+            }
+        if not self.configs["codec"]["encode_only"]:
+            accum_dec_by_module = {
+                key: accum_dec_by_module[key]
+                for key in ["inner_codec", "conversion", "feature_restoration"]
+                if key in accum_dec_by_module
+            }
+
         # if dec_only is True, accum_enc_by_module is None
         self.add_time_details("encode", accum_enc_by_module)
         # if enc_only is True, accum_dec_by_module is None


### PR DESCRIPTION
During the last FCM meeting, an issue was checked in one of the result files, `summary.csv`, where the runtime results for OIV6 did not match the order in the reporting template. It was found that when accumulating time per image in the image task, the `dict_sum` function in CompressAI Vision could shuffle the runtime order. (There is no issue with the accumulation operation itself.) A code snippet was added to re-sort the runtime order after processing 5,000 images.