### PR TITLE
[fix] integer convolution and unsplit

### DIFF
--- a/cfgs/vision_model/default.yaml
+++ b/cfgs/vision_model/default.yaml
@@ -34,7 +34,7 @@ panoptic_rcnn_R_101_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-PanopticSegmentation/panoptic_fpn_R_101_3x.yaml"
   weights: "weights/detectron2/COCO-PanopticSegmentation/panoptic_fpn_R_101_3x/139514519/model_final_cafdb1.pkl"
-  integer_conv_weight: False
+  integer_conv_weight: True
   splits : "fpn"
 
 jde_1088x608:

--- a/cfgs/vision_model/default.yaml
+++ b/cfgs/vision_model/default.yaml
@@ -6,41 +6,42 @@ faster_rcnn_R_50_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-Detection/faster_rcnn_R_50_FPN_3x/137849458/model_final_280758.pkl"
-  integer_conv_weight: False
+  integer_conv_weight: True
   splits : "r2" #, "c2" or "fpn"
 
 faster_rcnn_X_101_32x8d_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl"
-  integer_conv_weight: False
+  integer_conv_weight: True
   splits : "fpn" #, "c2" or "r2"
 
 mask_rcnn_R_50_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x/137849600/model_final_f10217.pkl"
-  integer_conv_weight: False
+  integer_conv_weight: True
   splits : "r2" #, "c2" or "fpn"
 
 mask_rcnn_X_101_32x8d_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_X_101_32x8d_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-InstanceSegmentation/mask_rcnn_X_101_32x8d_FPN_3x/139653917/model_final_2d9806.pkl"
-  integer_conv_weight: False
+  integer_conv_weight: True
   splits : "fpn" #, "c2" or "r2"
 
 panoptic_rcnn_R_101_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-PanopticSegmentation/panoptic_fpn_R_101_3x.yaml"
   weights: "weights/detectron2/COCO-PanopticSegmentation/panoptic_fpn_R_101_3x/139514519/model_final_cafdb1.pkl"
+  integer_conv_weight: False
   splits : "fpn"
 
 jde_1088x608:
   model_path_prefix: ${..model_root_path}
   cfg: "models/Towards-Realtime-MOT/cfg/yolov3_1088x608.cfg"
   weights: "weights/jde/jde.1088x608.uncertainty.pt"
-  integer_conv_weight: False
+  integer_conv_weight: True
   iou_thres: 0.5
   conf_thres: 0.5
   nms_thres: 0.4

--- a/cfgs/vision_model/default.yaml
+++ b/cfgs/vision_model/default.yaml
@@ -6,42 +6,42 @@ faster_rcnn_R_50_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-Detection/faster_rcnn_R_50_FPN_3x/137849458/model_final_280758.pkl"
-  integer_conv_weight: True
+  integer_conv_weight: False
   splits : "r2" #, "c2" or "fpn"
 
 faster_rcnn_X_101_32x8d_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl"
-  integer_conv_weight: True
+  integer_conv_weight: False
   splits : "fpn" #, "c2" or "r2"
 
 mask_rcnn_R_50_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x/137849600/model_final_f10217.pkl"
-  integer_conv_weight: True
+  integer_conv_weight: False
   splits : "r2" #, "c2" or "fpn"
 
 mask_rcnn_X_101_32x8d_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_X_101_32x8d_FPN_3x.yaml"
   weights: "weights/detectron2/COCO-InstanceSegmentation/mask_rcnn_X_101_32x8d_FPN_3x/139653917/model_final_2d9806.pkl"
-  integer_conv_weight: True
+  integer_conv_weight: False
   splits : "fpn" #, "c2" or "r2"
 
 panoptic_rcnn_R_101_FPN_3x:
   model_path_prefix: ${..model_root_path}
   cfg: "models/detectron2/configs/COCO-PanopticSegmentation/panoptic_fpn_R_101_3x.yaml"
   weights: "weights/detectron2/COCO-PanopticSegmentation/panoptic_fpn_R_101_3x/139514519/model_final_cafdb1.pkl"
-  integer_conv_weight: True
+  integer_conv_weight: False
   splits : "fpn"
 
 jde_1088x608:
   model_path_prefix: ${..model_root_path}
   cfg: "models/Towards-Realtime-MOT/cfg/yolov3_1088x608.cfg"
   weights: "weights/jde/jde.1088x608.uncertainty.pt"
-  integer_conv_weight: True
+  integer_conv_weight: False
   iou_thres: 0.5
   conf_thres: 0.5
   nms_thres: 0.4

--- a/scripts/evaluation/default_vision_performances.sh
+++ b/scripts/evaluation/default_vision_performances.sh
@@ -40,6 +40,7 @@ MPEG_OIV6_SRC="${TESTDATA_DIR}/mpeg-oiv6"
 SFU_HW_SRC="${TESTDATA_DIR}/SFU_HW_Obj"
 HIEVE_SRC="${TESTDATA_DIR}/HiEve_pngs"
 TVD_SRC="${TESTDATA_DIR}/tvd_tracking"
+PANDASET_SRC="${TESTDATA_DIR}/PandaSet"
 
 # MPEGOIV6 - Detection with Faster RCNN
 ${ENTRY_CMD} --config-name=${CONF_NAME}.yaml \
@@ -157,6 +158,64 @@ do
                  ++dataset.config.annotation_file=gt/gt.txt \
                  ++dataset.config.dataset_name=${SEQ} \
                  ++evaluator.type=MOT-HIEVE-EVAL \
+                 ++pipeline.nn_task_part1.load_features=False \
+                 ++pipeline.nn_task_part1.dump_features=False \
+                 ++pipeline.nn_task_part2.dump_features=False \
+                 ++misc.device.nn_parts=${DEVICE}
+done
+
+# PANDASET - Semantic Segmentation with Pandaset
+for SEQ in \
+            '003' \
+            '011' \
+            '016' \
+            '017' \
+            '021' \
+            '023' \
+            '027' \
+            '029' \
+            '030' \
+            '033' \
+            '035' \
+            '037' \
+            '039' \
+            '043' \
+            '053' \
+            '056' \
+            '057' \
+            '058' \
+            '069' \
+            '070' \
+            '072' \
+            '073' \
+            '077' \
+            '088' \
+            '089' \
+            '090' \
+            '095' \
+            '097' \
+            '109' \
+            '112' \
+            '113' \
+            '115' \
+            '117' \
+            '119' \
+            '122' \
+            '124'
+do
+    ${ENTRY_CMD} --config-name=${CONF_NAME}.yaml \
+                 ++pipeline.type=video \
+                 ++pipeline.conformance.save_conformance_files=True \
+                 ++pipeline.conformance.subsample_ratio=9 \
+                 ++vision_model.arch=panoptic_rcnn_R_101_FPN_3x \
+                 ++dataset.type=Detectron2Dataset \
+                 ++dataset.datacatalog=PANDASET \
+                 ++dataset.config.root=${PANDASET_SRC}/${SEQ} \
+                 ++dataset.config.imgs_folder=camera/front_camera \
+                 ++dataset.config.ext=jpg \
+                 ++dataset.config.annotation_file=annotations/${SEQ}.npz \
+                 ++dataset.config.dataset_name=pandaset-${SEQ} \
+                 ++evaluator.type=SEMANTICSEG-EVAL \
                  ++pipeline.nn_task_part1.load_features=False \
                  ++pipeline.nn_task_part1.dump_features=False \
                  ++pipeline.nn_task_part2.dump_features=False \


### PR DESCRIPTION
This is a PR for bug fixes related to the following MR in FCTM:
https://git.mpeg.expert/MPEG/Video/fcm/fctm/-/merge_requests/81#8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d

**There appear to be several items that need to be addressed on the CompressAI-Vision side:**

1. It appears that the unsplit performance evaluation code is missing support for Pandaset. `(added)`

2. Currently, all integer_conv_weight options are set to False by default in compressai_vision/cfgs/vision_model/default.yaml. Therefore, I have changed them to True. `(changed)`

3. When running panoptic segmentation, the integer_conv_weight key seems to be missing, for example, in compressai_vision/cfgs/vision_model/default.yaml. This key has been added for the function to work properly. `(added)`

4. When setting integer_conv_weight to True for panoptic segmentation, integer convolution does not seem to be working correctly. (There seems to be a bug.) `(FCTM side bug)`

5. Regarding the class-wise calculation, it seems that “Cactus” is still included. `(required)`

6. The kmac/pixels calculation code does not include PANDASET. `(required)`