### PR TITLE
Bug in class-wise complexity calculation

### DIFF
--- a/scripts/metrics/compute_overall_kmac_per_px.py
+++ b/scripts/metrics/compute_overall_kmac_per_px.py
@@ -87,6 +87,8 @@ def generate_csv_classwise_video_gmac(dataset_name, result_path, list_of_classwi
     for cls_seqs in list_of_classwise_seq:
         for cls_name, seqs in cls_seqs.items():
             complexity_lst_class_wise = []
+            if dataset_name == "PANDASET":
+                seqs = [ seq.replace("PANDA", "") for seq in seqs ]
 
             seq_path = [
                 next(name for name in seq_base_path if s in name)

--- a/scripts/metrics/compute_overall_kmac_per_px.py
+++ b/scripts/metrics/compute_overall_kmac_per_px.py
@@ -248,7 +248,8 @@ if __name__ == "__main__":
         }
 
         if args.dataset_name == "SFU" and args.no_cactus:
-            class_ab["CLASS-AB"].remove("Cactus_1920x1080_50")
+            if "Cactus_1920x1080_50" in class_ab["CLASS-AB"]:
+                class_ab["CLASS-AB"].remove("Cactus_1920x1080_50")
 
         output_df = generate_csv_classwise_video_gmac(
             args.dataset_name,


### PR DESCRIPTION
1. When using the no-cactus option for SFU classAB, an error occurred if the Cactus sequence was intentionally excluded from the experiment. This commit fixes that issue by properly handling the absence of Cactus.
2. Although the path issue for PANDASET was resolved in gen_mpeg_cttc_csv.py, it was not reflected in the complexity calculation script. This has now been fixed.
