### PR TITLE
[fix] Align Pandaset eval script with other scripts (minor)

### DIFF
--- a/scripts/evaluation/pandaset/eval_on_pandaset_hm.sh
+++ b/scripts/evaluation/pandaset/eval_on_pandaset_hm.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 FCM_TESTDATA=""
 INNER_CODEC_PATH=""
 OUTPUT_DIR=""
@@ -57,10 +59,11 @@ if [[ ${PIPELINE} == "remote" ]]; then
   CONF_NAME="eval_remote_inference_example.yaml"
 fi
 
-
-
-INTRA_PERIOD=32
-FRAME_RATE=30
+DATASET_INFO_PATH="${SCRIPT_DIR}/pandaset.json"
+SEQ_INFO=$(jq --compact-output ".sequences[] | select(.seq_name == \"${SEQ}\")" "$DATASET_INFO_PATH")
+[ -n "$SEQ_INFO" ] || exit 1
+INTRA_PERIOD=$(jq --raw-output ".intra_period" <<< "${SEQ_INFO}")
+FRAME_RATE=$(jq --raw-output ".frame_rate" <<< "${SEQ_INFO}")
 
 echo "============================== RUNNING COMPRESSAI-VISION EVAL== =================================="
 echo "Pipeline Type:      " ${PIPELINE} " Video"

--- a/scripts/evaluation/pandaset/eval_on_pandaset_vcmrs.sh
+++ b/scripts/evaluation/pandaset/eval_on_pandaset_vcmrs.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 FCM_TESTDATA=""
 INNER_CODEC_PATH=""
 OUTPUT_DIR=""
@@ -60,8 +62,11 @@ fi
 declare -A roi_descriptor
 declare -A spatial_descriptor
 
-INTRA_PERIOD=32
-FRAME_RATE=30
+DATASET_INFO_PATH="${SCRIPT_DIR}/pandaset.json"
+SEQ_INFO=$(jq --compact-output ".sequences[] | select(.seq_name == \"${SEQ}\")" "$DATASET_INFO_PATH")
+[ -n "$SEQ_INFO" ] || exit 1
+INTRA_PERIOD=$(jq --raw-output ".intra_period" <<< "${SEQ_INFO}")
+FRAME_RATE=$(jq --raw-output ".frame_rate" <<< "${SEQ_INFO}")
 
 echo "============================== RUNNING COMPRESSAI-VISION EVAL== =================================="
 echo "Pipeline Type:      " ${PIPELINE} " Video"

--- a/scripts/evaluation/pandaset/eval_on_pandaset_vtm.sh
+++ b/scripts/evaluation/pandaset/eval_on_pandaset_vtm.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 FCM_TESTDATA=""
 INNER_CODEC_PATH=""
 OUTPUT_DIR=""
@@ -57,10 +59,11 @@ if [[ ${PIPELINE} == "remote" ]]; then
   CONF_NAME="eval_remote_inference_example.yaml"
 fi
 
-
-
-INTRA_PERIOD=32
-FRAME_RATE=30
+DATASET_INFO_PATH="${SCRIPT_DIR}/pandaset.json"
+SEQ_INFO=$(jq --compact-output ".sequences[] | select(.seq_name == \"${SEQ}\")" "$DATASET_INFO_PATH")
+[ -n "$SEQ_INFO" ] || exit 1
+INTRA_PERIOD=$(jq --raw-output ".intra_period" <<< "${SEQ_INFO}")
+FRAME_RATE=$(jq --raw-output ".frame_rate" <<< "${SEQ_INFO}")
 
 echo "============================== RUNNING COMPRESSAI-VISION EVAL== =================================="
 echo "Pipeline Type:      " ${PIPELINE} " Video"

--- a/scripts/evaluation/pandaset/pandaset.json
+++ b/scripts/evaluation/pandaset/pandaset.json
@@ -1,0 +1,184 @@
+{
+  "sequences": [
+    {
+      "seq_name": "057",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "058",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "069",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "070",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "072",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "073",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "077",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "003",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "011",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "016",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "017",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "021",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "023",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "027",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "029",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "030",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "033",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "035",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "037",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "039",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "043",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "053",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "056",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "097",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "088",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "089",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "090",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "095",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "109",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "112",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "113",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "115",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "117",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "119",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "122",
+      "intra_period": 32,
+      "frame_rate": 30
+    },
+    {
+      "seq_name": "124",
+      "intra_period": 32,
+      "frame_rate": 30
+    }
+  ]
+}


### PR DESCRIPTION
I created a script to run the remote anchor, but the corresponding commit already existed.
However, the current script didn’t take the framerate and intra period from a file like the other scripts, so I simply aligned it accordingly.