### PR TITLE
[Update] Update MAC calculation code due to removal of temporal resampling

### DIFF
--- a/compressai_vision/pipelines/split_inference/video_split_inference.py
+++ b/compressai_vision/pipelines/split_inference/video_split_inference.py
@@ -351,12 +351,7 @@ class VideoSplitInference(BasePipeline):
 
         # Calculate mac considering number of coded feature frames
         if self.is_mac_calculation:
-            frames = (
-                len(dataloader) // 2 + 1
-                if codec.enc_tools["feature_reduction"]["temporal_resampling_enabled"]
-                is True
-                else len(dataloader)
-            )
+            frames = len(dataloader)
             self.calc_kmac_per_pixels_video_task(frames, len(dataloader))
 
         # performance evaluation on end-task


### PR DESCRIPTION
Remove temporal resampling MAC calculation code from CompressAI-Vision, as temporal resampling has been removed from FCM.