### PR TITLE
[feat] kmac calculation for yolox_darknet53

### DIFF
--- a/compressai_vision/model_wrappers/base_wrapper.py
+++ b/compressai_vision/model_wrappers/base_wrapper.py
@@ -65,6 +65,10 @@ class BaseWrapper(nn.Module):
         """Complete the downstream task with end-to-end manner all the way from the input"""
         raise NotImplementedError
 
+    def calc_complexity(self, mode, input, data):
+        """Computes the MACs Complexity of the model"""
+        raise NotImplementedError
+
     @property
     def cfg(self):
         return None

--- a/compressai_vision/model_wrappers/detectron2.py
+++ b/compressai_vision/model_wrappers/detectron2.py
@@ -36,6 +36,10 @@ import torch
 
 from compressai_vision.registry import register_vision_model
 
+from ..utils.measure_complexity import (
+    calc_complexity_nn_part1_plyr,
+    calc_complexity_nn_part2_plyr,
+)
 from .base_wrapper import BaseWrapper
 from .intconv2d import IntConv2d, IntTransposedConv2d
 
@@ -558,6 +562,17 @@ class Rcnn_R_50_X_101_FPN(BaseWrapper):
     @property
     def cfg(self):
         return self._cfg
+
+    def calc_complexity(self, mode, input, data=None):
+        """Computes the MACs Complexity of the model"""
+        if mode == "nn_part_1":
+            return calc_complexity_nn_part1_plyr(self, input)
+        elif mode == "nn_part_2":
+            return calc_complexity_nn_part2_plyr(self, input, data)
+        else:
+            raise NotImplementedError(
+                f"Complexity calculation for {mode} not implemented for Detectron2"
+            )
 
 
 @register_vision_model("faster_rcnn_X_101_32x8d_FPN_3x")

--- a/compressai_vision/model_wrappers/jde.py
+++ b/compressai_vision/model_wrappers/jde.py
@@ -36,6 +36,10 @@ import torch
 
 from compressai_vision.registry import register_vision_model
 
+from ..utils.measure_complexity import (
+    calc_complexity_nn_part1_dn53,
+    calc_complexity_nn_part2_dn53,
+)
 from .base_wrapper import BaseWrapper
 
 __all__ = [
@@ -489,3 +493,14 @@ class jde_1088x608(BaseWrapper):
                 online_ids.append(tid)
 
         return {"tlwhs": online_tlwhs, "ids": online_ids}
+
+    def calc_complexity(self, mode, input, data=None):
+        """Computes the MACs Complexity of the model"""
+        if mode == "nn_part_1":
+            return calc_complexity_nn_part1_dn53(self, input)
+        elif mode == "nn_part_2":
+            return calc_complexity_nn_part2_dn53(self, input)
+        else:
+            raise NotImplementedError(
+                f"Complexity calculation for {mode} not implemented for JDE"
+            )

--- a/compressai_vision/model_wrappers/yolox.py
+++ b/compressai_vision/model_wrappers/yolox.py
@@ -36,6 +36,10 @@ import torch
 
 from compressai_vision.registry import register_vision_model
 
+from ..utils.measure_complexity import (
+    calc_complexity_nn_part1_yolox,
+    calc_complexity_nn_part2_yolox,
+)
 from .base_wrapper import BaseWrapper
 from .split_squeezes import squeeze_yolox
 
@@ -326,3 +330,14 @@ class yolox_darknet53(BaseWrapper):
         )
 
         return pred
+
+    def calc_complexity(self, mode, input, data=None):
+        """Computes the MACs Complexity of the model"""
+        if mode == "nn_part_1":
+            return calc_complexity_nn_part1_yolox(self, input)
+        elif mode == "nn_part_2":
+            return calc_complexity_nn_part2_yolox(self, input)
+        else:
+            raise NotImplementedError(
+                f"Complexity calculation for {mode} not implemented for YOLOX-Darknet53"
+            )

--- a/compressai_vision/pipelines/split_inference/image_split_inference.py
+++ b/compressai_vision/pipelines/split_inference/image_split_inference.py
@@ -111,7 +111,7 @@ class ImageSplitInference(BasePipeline):
                     break
 
                 if self.is_mac_calculation:
-                    macs, pixels = calc_complexity_nn_part1_plyr(vision_model, d)
+                    macs, pixels = vision_model.calc_complexity("nn_part_1", d)
                     self.acc_kmac_and_pixels_info("nn_part_1", macs, pixels)
 
                 start = time_measure()
@@ -200,8 +200,8 @@ class ImageSplitInference(BasePipeline):
             dec_features["file_name"] = d[0]["file_name"]
             dec_features["file_origin"] = d[0]["file_name"]
             if self.is_mac_calculation:
-                macs, pixels = calc_complexity_nn_part2_plyr(
-                    vision_model, dec_features["data"], dec_features
+                macs, pixels = vision_model.calc_complexity(
+                    "nn_part_2", dec_features, dec_features["data"]
                 )
                 self.acc_kmac_and_pixels_info("nn_part_2", macs, pixels)
 

--- a/compressai_vision/pipelines/split_inference/video_split_inference.py
+++ b/compressai_vision/pipelines/split_inference/video_split_inference.py
@@ -140,10 +140,7 @@ class VideoSplitInference(BasePipeline):
                     break
 
                 if self.is_mac_calculation and e == self._codec_skip_n_frames:
-                    if hasattr(vision_model, "darknet"):  # for jde
-                        kmacs, pixels = calc_complexity_nn_part1_dn53(vision_model, d)
-                    else:  # for detectron2
-                        kmacs, pixels = calc_complexity_nn_part1_plyr(vision_model, d)
+                    kmacs, pixels = vision_model.calc_complexity("nn_part_1", d)
                     self.add_kmac_and_pixels_info("nn_part_1", kmacs, pixels)
 
                 start = time_measure()
@@ -299,14 +296,9 @@ class VideoSplitInference(BasePipeline):
             )  # Assuming one qp will be used
 
             if self.is_mac_calculation and e == 0:
-                if hasattr(vision_model, "darknet"):  # for jde
-                    kmacs, pixels = calc_complexity_nn_part2_dn53(
-                        vision_model, dec_features
-                    )
-                else:  # for detectron2
-                    kmacs, pixels = calc_complexity_nn_part2_plyr(
-                        vision_model, data, dec_features
-                    )
+                kmacs, pixels = vision_model.calc_complexity(
+                    "nn_part_2", dec_features, data
+                )
                 self.add_kmac_and_pixels_info("nn_part_2", kmacs, pixels)
 
             start = time_measure()


### PR DESCRIPTION
This PR implements support for MAC calculation for YOLOX. In addition, I moved the MAC calculation for each vision model into the model wrapper so that, in split inference, they can be invoked through a single function call. If you feel this approach is not appropriate, please let me know and I can further modify it. Feel free to take all or part of these changes. Thanks.