### PR TITLE
[fix] check decoded feature hash for image split inference

### DIFF
--- a/compressai_vision/pipelines/split_inference/image_split_inference.py
+++ b/compressai_vision/pipelines/split_inference/image_split_inference.py
@@ -286,7 +286,10 @@ class ImageSplitInference(BasePipeline):
             out_res["coded_order"] = e
             out_res["org_input_size"] = f"{d[0]['height']}x{d[0]['width']}"
             out_res["input_size"] = dec_features["input_size"][0]
-            if "decoded_feature_tensor_hash" in dec_features:
+            if (
+                "decoded_feature_tensor_hash" in dec_features
+                and dec_features["decoded_feature_tensor_hash"] is not None
+            ):
                 out_res["decoded_feature_tensor_hash"] = (
                     dec_features["decoded_feature_tensor_hash"][e]
                     if e in dec_features["decoded_feature_tensor_hash"]


### PR DESCRIPTION
This PR fixes a runtime error when accessing `decoded_feature_tensor_hash` from decoded feature data in image split inference.