### PR TITLE
[fix] fix image pipeline handling of missing decoded feature tensor hash

### DIFF
--- a/compressai_vision/pipelines/split_inference/image_split_inference.py
+++ b/compressai_vision/pipelines/split_inference/image_split_inference.py
@@ -286,7 +286,10 @@ class ImageSplitInference(BasePipeline):
             out_res["coded_order"] = e
             out_res["org_input_size"] = f"{d[0]['height']}x{d[0]['width']}"
             out_res["input_size"] = dec_features["input_size"][0]
-            if "decoded_feature_tensor_hash" in dec_features:
+            if (
+                "decoded_feature_tensor_hash" in dec_features
+                and dec_features["decoded_feature_tensor_hash"] is not None
+            ):
                 out_res["decoded_feature_tensor_hash"] = (
                     dec_features["decoded_feature_tensor_hash"][e]
                     if e in dec_features["decoded_feature_tensor_hash"]


### PR DESCRIPTION
A runtime error occurs in the image pipeline when the decoded feature tensor hash is not present.

The FCTM decoder returns `None` for `decoded_feature_tensor_hash` when the corresponding SEI message is disabled or absent. Although the video pipeline already handles this case by checking that the value is not `None`, the equivalent check was missing from the image pipeline. As a result, the image pipeline attempted to evaluate membership against `None`, raising a `TypeError`.